### PR TITLE
feat: add Currently building section with featured projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 [![An image of @karankeyash0's Holopin badges, which is a link to view their full Holopin profile](https://holopin.me/karankeyash0)](https://holopin.io/@karankeyash0)
 
+### Currently building
+
+- **[bombay-duck](https://github.com/dextel2/bombay-duck)** — Real-time BSE award announcement watcher that snapshots results to the README and keeps traders in the loop via GitHub Actions.
+- **[scale-sentry-ai](https://github.com/dextel2/scale-sentry-ai)** — AI GitHub Action that analyzes PR diffs for scalability bottlenecks (1K–100K req/s) and suggests concrete optimizations.
+- **[telegram-bot](https://github.com/dextel2/telegram-bot)** — Sample Telegram bot with AI integration.
+
 ### Languages and Tools: 
 
 <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/javascript/javascript.png"></code>


### PR DESCRIPTION
## Summary
Implements Priority 1 from the profile enhancement plan: a **Currently building** section with 3 high-signal public projects.

Closes #6

## Changes
- Added `### Currently building` after Holopin badges and before Languages and Tools
- Featured projects:
  - [bombay-duck](https://github.com/dextel2/bombay-duck)
  - [scale-sentry-ai](https://github.com/dextel2/scale-sentry-ai)
  - [telegram-bot](https://github.com/dextel2/telegram-bot)
- Bullet format to match existing README style

## Decisions
All defaults documented on [#6](https://github.com/dextel2/dextel2/issues/6) for observability. Override via review comments if preferred.

## Checklist
- [x] Section present with clear heading
- [x] 3 projects with accurate one-liners and working links
- [x] Higher visual priority than tech icons / WakaTime
- [x] Tone matches existing voice
- [x] No broken links