### PR TITLE
chore(waka): dual language stats sections + pin v0.3.1

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,32 +1,61 @@
 name: Waka Readme
 
 on:
-  # for manual workflow trigger
   workflow_dispatch:
   schedule:
     # runs at 12 AM UTC (5:30 AM IST)
     - cron: "0 0 * * *"
 
 jobs:
-  update-readme:
-    name: WakaReadme DevMetrics
+  update-week:
+    name: WakaReadme last_7_days
     runs-on: ubuntu-latest
     steps:
-      - uses: athul/waka-readme@master
+      - uses: athul/waka-readme@v0.3.1
         with:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
-          BLOCKS: -> 
-          CODE_LANG: rust 
-          SHOW_TIME: true 
-          SHOW_TOTAL: true 
-          SHOW_MASKED_TIME: false 
-          STOP_AT_OTHER: true 
-          ### commit
-          COMMIT_MESSAGE: The stats are updated, master ⚡! I live to serve!
-          TARGET_BRANCH: main 
-          COMMITTER_NAME: Yash Karanke 
-          COMMITTER_EMAIL: ${{ secrets.EMAIL }} 
-          AUTHOR_NAME: Yash Karanke 
-          AUTHOR_EMAIL: ${{ secrets.EMAIL }} 
-          # you can populate email-id with secretes instead
+          SECTION_NAME: waka
+          TIME_RANGE: last_7_days
+          SHOW_TITLE: true
+          SHOW_TIME: true
+          SHOW_TOTAL: true
+          SHOW_MASKED_TIME: false
+          LANG_COUNT: 8
+          STOP_AT_OTHER: false
+          IGNORED_LANGUAGES: JSON YAML TOML
+          BLOCKS: "->"
+          CODE_LANG: rust
+          TARGET_BRANCH: main
+          COMMIT_MESSAGE: "chore(waka): update last_7_days language stats"
+          COMMITTER_NAME: Yash Karanke
+          COMMITTER_EMAIL: ${{ secrets.EMAIL }}
+          AUTHOR_NAME: Yash Karanke
+          AUTHOR_EMAIL: ${{ secrets.EMAIL }}
+
+  update-alltime:
+    name: WakaReadme all_time
+    needs: update-week
+    runs-on: ubuntu-latest
+    steps:
+      - uses: athul/waka-readme@v0.3.1
+        with:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+          SECTION_NAME: wakaall
+          TIME_RANGE: all_time
+          SHOW_TITLE: true
+          SHOW_TIME: true
+          SHOW_TOTAL: true
+          SHOW_MASKED_TIME: false
+          LANG_COUNT: 10
+          STOP_AT_OTHER: false
+          IGNORED_LANGUAGES: JSON YAML TOML
+          BLOCKS: "->"
+          CODE_LANG: rust
+          TARGET_BRANCH: main
+          COMMIT_MESSAGE: "chore(waka): update all_time language stats"
+          COMMITTER_NAME: Yash Karanke
+          COMMITTER_EMAIL: ${{ secrets.EMAIL }}
+          AUTHOR_NAME: Yash Karanke
+          AUTHOR_EMAIL: ${{ secrets.EMAIL }}

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/aws/aws.png"></code>
 <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/git/git.png"></code>
 
- 
-### Language statistics...
+### Coding this week
 
 <!--START_SECTION:waka-->
 
@@ -45,7 +44,15 @@ Other        6 hrs 12 mins         >>>----------------------   11.32 %
 
 <!--END_SECTION:waka-->
 
+### All-time languages
 
+<!--START_SECTION:wakaall-->
+
+```rust
+<!-- populated by athul/waka-readme (all_time) -->
+```
+
+<!--END_SECTION:wakaall-->
 
 ## My Latest Blog Posts 👇
 
@@ -59,7 +66,5 @@ Other        6 hrs 12 mins         >>>----------------------   11.32 %
 
 <!-- HASHNODE_BLOG:END -->
 
-
-
-### All time Coding Hours                                                                                                                                                 
+### All time Coding Hours
 [![wakatime](https://wakatime.com/badge/user/efc4928d-c420-4b31-a817-99b0e6502a8b.svg)](https://wakatime.com/@efc4928d-c420-4b31-a817-99b0e6502a8b)


### PR DESCRIPTION
## Summary
Implements the locked decisions from #8 for richer, clearer WakaTime stats on the profile README.

Closes #9, #10, #11, #12  
Related: #8

## Changes

### Workflow (`.github/workflows/update-stats.yml`)
- Pin **`athul/waka-readme@v0.3.1`** (was `@master`)
- **Job `update-week`:** `last_7_days` → `SECTION_NAME: waka`
- **Job `update-alltime`:** `all_time` → `SECTION_NAME: wakaall` (runs after week job to avoid README SHA races)
- Flags: `SHOW_TITLE`, `LANG_COUNT` 8/10, `STOP_AT_OTHER: false`
- `IGNORED_LANGUAGES: JSON YAML TOML` (Markdown kept — writing is part of public signal)

### README
- `### Coding this week` + existing `waka` markers
- `### All-time languages` + new `wakaall` markers
- All-time hours badge retained

## Post-merge
1. Run **Actions → Waka Readme → Run workflow** once so both sections fill from the API.
2. Confirm `wakaall` populates (placeholder until first successful all_time run).

## Decisions (from #8)
| Item | Choice |
|------|--------|
| Primary range | `last_7_days` |
| Dual section | yes (`wakaall` / `all_time`) |
| Markdown | keep |
| Stack | v0.3.1 only |