### PR TITLE
chore(waka): drop all_time; add real Coding today (24h calendar day)

### DIFF
--- a/.github/scripts/waka-today.py
+++ b/.github/scripts/waka-today.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Fetch today's WakaTime language stats and inject into README markers.
+
+Uses Summaries API (not Stats all_time). Section: wakatoday
+Compatible with free-tier same-day data; no long-range 202 calc delay.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import sys
+from datetime import date, datetime, timezone
+
+import urllib.error
+import urllib.request
+import json
+
+SECTION = "wakatoday"
+START = f"<!--START_SECTION:{SECTION}-->"
+END = f"<!--END_SECTION:{SECTION}-->"
+BLOCK_STYLE = "->"
+GRAPH_LEN = 25
+LANG_COUNT = 8
+IGNORED = {"JSON", "YAML", "TOML"}
+README_PATH = os.environ.get("README_PATH", "README.md")
+
+
+def basic_auth_header(api_key: str) -> str:
+    token = base64.b64encode(api_key.encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def make_graph(percent: float) -> str:
+    markers = len(BLOCK_STYLE) - 1
+    proportion = percent / 100 * GRAPH_LEN
+    bar = BLOCK_STYLE[-1] * int(proportion + 0.5 / markers)
+    remainder = int((proportion - len(bar)) * markers + 0.5)
+    if remainder > 0:
+        bar += BLOCK_STYLE[remainder]
+    bar += BLOCK_STYLE[0] * (GRAPH_LEN - len(bar))
+    return bar
+
+
+def fetch_today_summary(api_key: str) -> dict:
+    # User-local "today" is ideal; UTC date is a reasonable Actions default.
+    today = date.today().isoformat()
+    url = (
+        "https://wakatime.com/api/v1/users/current/summaries"
+        f"?start={today}&end={today}"
+    )
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": basic_auth_header(api_key),
+            "User-Agent": "dextel2-waka-today/1.0",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", errors="replace")
+        print(f"WakaTime HTTP {err.code}: {body}", file=sys.stderr)
+        sys.exit(1)
+    data = payload.get("data") or []
+    if not data:
+        return {"date": today, "grand_total": {"text": "0 secs"}, "languages": []}
+    return data[0]
+
+
+def format_block(day: dict) -> str:
+    day_date = day.get("range", {}).get("date") or day.get("range", {}).get("start", "")
+    if day_date and "T" in str(day_date):
+        try:
+            day_date = datetime.fromisoformat(str(day_date).replace("Z", "+00:00")).strftime(
+                "%d %B %Y"
+            )
+        except ValueError:
+            day_date = str(day_date)[:10]
+    elif day_date:
+        try:
+            day_date = datetime.strptime(str(day_date)[:10], "%Y-%m-%d").strftime("%d %B %Y")
+        except ValueError:
+            pass
+
+    total = (day.get("grand_total") or {}).get("text") or "0 secs"
+    lines = [f"Today: {day_date}", "", f"Total Time: {total}", ""]
+
+    languages = day.get("languages") or []
+    filtered = [lg for lg in languages if str(lg.get("name")) not in IGNORED]
+    if not filtered:
+        lines.append("No activity tracked today")
+        return "\n".join(lines)
+
+    pad = max(len(str(lg.get("name", ""))) for lg in filtered[:LANG_COUNT])
+    for lg in filtered[:LANG_COUNT]:
+        name = str(lg.get("name", "?"))
+        text = str(lg.get("text", ""))
+        percent = float(lg.get("percent") or 0.0)
+        bar = make_graph(percent)
+        lines.append(
+            f"{name.ljust(pad)}   {text: <16}{bar}   {percent:05.2f} %"
+        )
+    return "\n".join(lines)
+
+
+def inject_readme(content: str, block: str) -> str:
+    pattern = re.compile(
+        re.escape(START) + r"[\s\S]*?" + re.escape(END),
+        re.MULTILINE,
+    )
+    if not pattern.search(content):
+        print(f"Markers {START} … {END} not found in {README_PATH}", file=sys.stderr)
+        sys.exit(1)
+    replacement = f"{START}\n\n```rust\n{block}\n```\n\n{END}"
+    return pattern.sub(replacement, content)
+
+
+def main() -> None:
+    api_key = os.environ.get("WAKATIME_API_KEY")
+    if not api_key:
+        print("WAKATIME_API_KEY is required", file=sys.stderr)
+        sys.exit(1)
+
+    summary = fetch_today_summary(api_key)
+    block = format_block(summary)
+    print(block)
+
+    with open(README_PATH, encoding="utf-8") as fh:
+        readme = fh.read()
+    updated = inject_readme(readme, block)
+    if updated == readme:
+        print("README unchanged")
+        return
+    with open(README_PATH, "w", encoding="utf-8") as fh:
+        fh.write(updated)
+    print(f"Updated {README_PATH} section {SECTION}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -33,29 +33,33 @@ jobs:
           AUTHOR_NAME: Yash Karanke
           AUTHOR_EMAIL: ${{ secrets.EMAIL }}
 
-  update-alltime:
-    name: WakaReadme 24h
+  update-today:
+    name: WakaTime today (24h calendar day)
     needs: update-week
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: athul/waka-readme@v0.3.1
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
+          ref: main
+
+      - name: Render today's language stats
+        env:
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
-          SECTION_NAME: wakaall
-          TIME_RANGE: 24h
-          SHOW_TITLE: true
-          SHOW_TIME: true
-          SHOW_TOTAL: true
-          SHOW_MASKED_TIME: false
-          LANG_COUNT: 10
-          STOP_AT_OTHER: false
-          IGNORED_LANGUAGES: JSON YAML TOML
-          BLOCKS: "->"
-          CODE_LANG: rust
-          TARGET_BRANCH: main
-          COMMIT_MESSAGE: "chore(waka): update all_time language stats"
-          COMMITTER_NAME: Yash Karanke
-          COMMITTER_EMAIL: ${{ secrets.EMAIL }}
-          AUTHOR_NAME: Yash Karanke
-          AUTHOR_EMAIL: ${{ secrets.EMAIL }}
+          README_PATH: README.md
+        run: python3 .github/scripts/waka-today.py
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "Yash Karanke"
+          git config user.email "${{ secrets.EMAIL }}"
+          git add README.md
+          if git diff --staged --quiet; then
+            echo "No README changes for today section"
+            exit 0
+          fi
+          git commit -m "chore(waka): update today language stats"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -51,28 +51,15 @@ JavaScript   51 mins         -------------------------   01.57 %
 
 <!--END_SECTION:waka-->
 
-### All-time languages
+### Coding today
 
-<!--START_SECTION:wakaall-->
+<!--START_SECTION:wakatoday-->
 
 ```rust
-From: 22 July 2026 - To: 29 July 2026
-
-Total Time: 48 hrs 51 mins
-
-Markdown     22 hrs 18 mins  >>>>>>>>>>---------------   40.68 %
-TypeScript   12 hrs 24 mins  >>>>>>-------------------   22.61 %
-Other        5 hrs 58 mins   >>>----------------------   10.90 %
-HTML         3 hrs 30 mins   >>-----------------------   06.41 %
-PHP          2 hrs 14 mins   >------------------------   04.10 %
-Text         1 hr 56 mins    >------------------------   03.55 %
-JSON         1 hr 53 mins    >------------------------   03.45 %
-Bash         1 hr 5 mins     -------------------------   01.99 %
-JavaScript   52 mins         -------------------------   01.60 %
-Docker       43 mins         -------------------------   01.32 %
+<!-- populated by .github/scripts/waka-today.py (calendar day) -->
 ```
 
-<!--END_SECTION:wakaall-->
+<!--END_SECTION:wakatoday-->
 
 ## My Latest Blog Posts 👇
 


### PR DESCRIPTION
## Why
`all_time` was slow (HTTP 202 calc) and for this account looked like ~1 week of data.

`TIME_RANGE: 24h` is **not** valid in `athul/waka-readme@v0.3.1` — unknown ranges silently fall back to `last_7_days` (duplicate of the weekly block).

## What changed
| Section | Source |
|---------|--------|
| **Coding this week** | `athul/waka-readme@v0.3.1` → `last_7_days` (unchanged) |
| **Coding today** | New `.github/scripts/waka-today.py` → WakaTime **Summaries API** for the current calendar day |

- Removed `all_time` / invalid `24h` Stats range
- Markers: `wakatoday`
- Ignores `JSON` / `YAML` / `TOML` (same policy as weekly)
- Still no project names (privacy)

## Note on “24h”
This is **today’s calendar day** in the runner’s date (UTC on `ubuntu-latest`), not a rolling last-24-hours window. That matches WakaTime’s summaries `start`/`end` day model and avoids Stats `all_time` 202 delays.

## Post-merge
Run **Waka Readme** once via `workflow_dispatch` to fill “Coding today”.

Related: #8