### PR TITLE
docs(readme): clarify lifetime hours badge (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,8 @@ Markdown   2 mins          >>>----------------------   12.36 %
 
 <!-- HASHNODE_BLOG:END -->
 
-### All time Coding Hours
+### Lifetime coding hours
+
+Total time tracked in WakaTime (all years). Language breakdowns above are **this week** and **today** only — not lifetime mix.
+
 [![wakatime](https://wakatime.com/badge/user/efc4928d-c420-4b31-a817-99b0e6502a8b.svg)](https://wakatime.com/@efc4928d-c420-4b31-a817-99b0e6502a8b)


### PR DESCRIPTION
## Closes #12

### Done
- Headings already match ranges: **Coding this week** / **Coding today** (from #13/#14)
- Badge section renamed **Lifetime coding hours**
- One-line note: badge = total hours; language lists = week + today only (not lifetime mix)

### Policy (locked on #8)
| Language | Policy |
|----------|--------|
| Markdown | **Keep** (writing is public signal) |
| JSON / YAML / TOML | Ignore when the pipeline supports it |

**Note:** `athul/waka-readme@v0.3.1` has a generator bug in `IGNORED_LANGUAGES` (`in` exhausts a one-shot generator), so weekly JSON may still appear. Today section uses a `set` and filters correctly. Fixing weekly ignore would need upstream or a custom week renderer — out of scope for this issue.

Related: #8