### PR TITLE
fix(waka): pin past v0.3.1 so IGNORED_LANGUAGES works

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -11,7 +11,9 @@ jobs:
     name: WakaReadme last_7_days
     runs-on: ubuntu-latest
     steps:
-      - uses: athul/waka-readme@v0.3.1
+      # Pin past v0.3.1: IGNORED_LANGUAGES uses set() (653fcb25). No newer tag yet.
+      # https://github.com/athul/waka-readme/commit/653fcb25e91ba4014433cad6fc3171e87e7c0fd2
+      - uses: athul/waka-readme@370590ad8da8f54282ed92aa42b7c25ecbd5a9a6
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}


### PR DESCRIPTION
## Bug
`athul/waka-readme@v0.3.1` builds a **generator** for ignored languages, then uses `lang_name in ignored_languages`. The first `in` check exhausts the generator, so `JSON` / `YAML` / `TOML` never get filtered on the weekly block.

## Upstream status
Already fixed on **master** in [653fcb25](https://github.com/athul/waka-readme/commit/653fcb25e91ba4014433cad6fc3171e87e7c0fd2):

```python
ignored_languages = set(_extract_ignored_languages())
```

**No release tag after v0.3.1** (May 2024), so the fix is not available as `@v0.3.2`.

## This PR
Pin weekly job to immutable SHA on current master:

`athul/waka-readme@370590ad8da8f54282ed92aa42b7c25ecbd5a9a6`

(includes the `set()` fix + later master fixes such as GitHub auth deprecation).

## Follow-up (manual)
Open an issue on [athul/waka-readme](https://github.com/athul/waka-readme/issues) asking for a **v0.3.2** (or later) tag so we can pin a release instead of a SHA. App token could not create that issue (403).

After merge: run **Waka Readme** once and confirm JSON drops from the week block.